### PR TITLE
Fix quadratic text fitting that timed out PPTX generation

### DIFF
--- a/src/pptx/__init__.py
+++ b/src/pptx/__init__.py
@@ -25,7 +25,11 @@ from pptx.parts.slide import (
 if TYPE_CHECKING:
     from pptx.opc.package import Part
 
-__version__ = "1.0.2"
+# PEP 440 local version: upstream 1.0.2 plus this fork's patches. Bump the
+# trailing number on every fork change that needs to reach a deployed app --
+# pip resolves a git branch requirement by version, so an unchanged version
+# means it re-clones and then skips the install, silently leaving stale code.
+__version__ = "1.0.2+pptxbuilder.1"
 
 sys.modules["pptx.exceptions"] = exceptions
 del sys

--- a/src/pptx/text/layout.py
+++ b/src/pptx/text/layout.py
@@ -46,9 +46,37 @@ class TextFitter(tuple):
         *line_source* that will fit in this fitter's width and *remainder* is
         a |_LineSource| object containing the text following the break point.
         """
-        lines = _BinarySearchTree.from_ordered_sequence(line_source)
+        words = line_source._text.split()
+        if not words:
+            return None
         predicate = self._fits_in_width_predicate(point_size)
-        return lines.find_max(predicate)
+
+        def fits(word_count):
+            return predicate(_Line(" ".join(words[:word_count]), None))
+
+        # ---not even one word fits, so there is no break point---
+        if not fits(1):
+            return None
+
+        # Gallop upward to bracket the break point before binary searching, so
+        # that every probe string stays within ~2x the final line length. A
+        # search over the whole word list instead makes its first probe half of
+        # the *remaining* text, which is what made fitting a long placeholder
+        # quadratic in its word count.
+        lo, hi = 1, 2
+        while hi < len(words) and fits(hi):
+            lo, hi = hi, hi * 2
+        hi = min(hi, len(words))
+
+        # ---largest word count in [lo, hi] that still fits---
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if fits(mid):
+                lo = mid
+            else:
+                hi = mid - 1
+
+        return _Line(" ".join(words[:lo]), _LineSource(" ".join(words[lo:])))
 
     def _fits_in_width_predicate(self, point_size):
         """
@@ -109,19 +137,33 @@ class TextFitter(tuple):
         """
         Return a sequence of str values representing the text in
         *line_source* wrapped within this fitter when rendered at
-        *point_size*.
+        *point_size*, or |None| if it cannot be wrapped to fit.
         """
-        result = self._break_line(line_source, point_size)
-        if result is None:
-            return None
-        text, remainder = result
-        lines = [text]
-        if remainder:
-            remaining_lines = self._wrap_lines(remainder, point_size)
-            if remaining_lines is None:
+        # Once the wrapped text is taller than the frame, the point size has
+        # already lost; there is no reason to keep wrapping the remaining
+        # words. Oversized candidate sizes bail after a couple of lines rather
+        # than wrapping the whole text first. `_height` is None in unit
+        # fixtures that exercise wrapping in isolation, so cap only when known.
+        max_lines = None
+        if self._height is not None:
+            line_height = _rendered_size("Ty", point_size, self._font_file)[1]
+            if line_height <= 0:
                 return None
-            lines.extend(remaining_lines)
-        return lines
+            max_lines = self._height // line_height
+
+        # Iterative rather than recursive: a long text frame at a small point
+        # size wraps to more lines than the interpreter's recursion limit.
+        lines = []
+        while True:
+            result = self._break_line(line_source, point_size)
+            if result is None:
+                return None
+            text, line_source = result
+            lines.append(text)
+            if max_lines is not None and len(lines) > max_lines:
+                return None
+            if not line_source:
+                return lines
 
 
 class _BinarySearchTree(object):

--- a/tests/text/test_layout.py
+++ b/tests/text/test_layout.py
@@ -106,20 +106,53 @@ class DescribeTextFitter(object):
             call(text_fitter, remainder, 21),
         ]
 
-    def it_breaks_off_a_line_to_help_wrap(self, request, line_source_, _BinarySearchTree_):
-        bst_ = instance_mock(request, _BinarySearchTree)
-        _fits_in_width_predicate_ = method_mock(request, TextFitter, "_fits_in_width_predicate")
-        _BinarySearchTree_.from_ordered_sequence.return_value = bst_
-        predicate_ = _fits_in_width_predicate_.return_value
-        max_value_ = bst_.find_max.return_value
-        text_fitter = TextFitter(None, (None, None), None)
+    def it_breaks_off_a_line_to_help_wrap(self, _rendered_size_):
+        # ---10 EMU per character, 50 EMU wide, so 5 characters fit---
+        _rendered_size_.side_effect = lambda text, size, font: (len(text) * 10, 10)
+        text_fitter = TextFitter(None, (50, None), "foobar.ttf")
 
-        value = text_fitter._break_line(line_source_, 21)
+        line, remainder = text_fitter._break_line(_LineSource("aa bb cc dd"), 21)
 
-        _BinarySearchTree_.from_ordered_sequence.assert_called_once_with(line_source_)
-        text_fitter._fits_in_width_predicate.assert_called_once_with(text_fitter, 21)
-        bst_.find_max.assert_called_once_with(predicate_)
-        assert value is max_value_
+        assert line == "aa bb"
+        assert remainder == _LineSource("cc dd")
+
+    def it_breaks_off_the_whole_source_when_it_all_fits(self, _rendered_size_):
+        _rendered_size_.side_effect = lambda text, size, font: (len(text) * 10, 10)
+        text_fitter = TextFitter(None, (500, None), "foobar.ttf")
+
+        line, remainder = text_fitter._break_line(_LineSource("aa bb cc dd"), 21)
+
+        assert line == "aa bb cc dd"
+        assert not remainder
+
+    def but_it_breaks_off_no_line_when_the_first_word_does_not_fit(self, _rendered_size_):
+        _rendered_size_.side_effect = lambda text, size, font: (len(text) * 10, 10)
+        text_fitter = TextFitter(None, (10, None), "foobar.ttf")
+
+        assert text_fitter._break_line(_LineSource("aa bb cc dd"), 21) is None
+
+    def it_probes_a_logarithmic_number_of_break_points(self, _rendered_size_):
+        """Guards the fix for the quadratic-fitting timeout (pptxbuilder #2993).
+
+        The line break must be found by galloping + binary search, never by
+        measuring every candidate prefix -- a 1,000-word placeholder used to
+        push megabytes of substrings through PIL for a single line break.
+        """
+        probes = []
+
+        def measure(text, size, font):
+            probes.append(text)
+            return (len(text) * 10, 10)
+
+        _rendered_size_.side_effect = measure
+        # ---1,000 words, 20 of which fit in the 59-character width---
+        text_fitter = TextFitter(None, (590, None), "foobar.ttf")
+
+        line, _ = text_fitter._break_line(_LineSource(" ".join(["aa"] * 1000)), 21)
+
+        assert line == " ".join(["aa"] * 20)
+        assert len(probes) < 20, "break point search is not logarithmic"
+        assert max(len(p) for p in probes) < 200, "probe strings scale with the remainder"
 
     # fixtures ---------------------------------------------
 


### PR DESCRIPTION
Fixes the PPTX download timeout in pptxbuilder [issue #2993](https://github.com/Indico-Labs/pptxbuilder/issues/2993).

## What was happening

A 75-slide deck spent **56.4s of its 60s Celery budget inside `TextFitter`** and was hard-killed before it could save, so the download 404'd. It was 3 slides from finishing.

It's not the charts — it's text slides. Per-slide timings from the production worker log, cross-referenced against the customer's payload:

| slide | time | type |
|---|---|---|
| 41 | **12.40s** | text |
| 44 | **11.14s** | text |
| 43 | 5.18s | text |
| 42 | 5.05s | text |
| *all 25 chart slides* | ~0.1s each | charts |

Cost is superlinear in word count: 10 words → 0.00s, 339 words → 2.7s, 1,018 words → 18.9s.

## The two hot spots

**`_break_line`** built *every* candidate line via `_LineSource.__iter__` (`" ".join(words[:idx])` for every idx) and loaded them all into a BST whose `find_max` only ever probes ~log₂(W) of them. For one placeholder that was **168,964 candidate lines constructed and 2.4 MB of substrings pushed through PIL** to place a single line.

It now gallops upward to bracket the break point, then binary searches inside that bracket — every probe string stays within ~2× the final line length instead of starting at half the remaining text.

**`_wrap_lines`** wrapped the entire text before the caller compared line count against the frame height, so a candidate point size that was far too large still wrapped all 1,018 words before being rejected. It now knows the height budget and bails as soon as the line count exceeds it. Making it iterative also removes the deep-recursion path that `shrink_text_to_fit` currently has to catch with `except RecursionError`.

I also prototyped memoizing `_rendered_size` and **dropped it** — an ablation showed it was noise (129.09s vs 128.79s baseline), so it was only an unbounded dict keyed on full text strings sitting in a long-lived Celery worker.

## Results

Measured against the payload and template attached to issue #2993, over the 51 text frames it contains:

| | before | after | |
|---|---|---|---|
| all 51 frames | 128.9s | **17.6s** | 7.3× |
| worst frame | 18.9s | **1.6s** | 11.8× |
| end-to-end via `shrink_text_to_fit` on the customer's template | 18.69s | **1.56s** | 12× |

**Every frame resolves to an identical font size, and the generated slide XML is byte-identical.** This is a pure performance change.

Projected effect on the failing job: ~11s, and ~22s even assuming the fitter is only a third of text-slide cost.

## Tests

Full suite: **2680 pass** (2677 before + 3 new). The 8 failures / 16 errors in `tests/opc/` pre-exist on a clean tree — confirmed by stashing.

`it_breaks_off_a_line_to_help_wrap` asserted the BST mechanics this replaces, so it was testing the implementation rather than the behaviour; it now asserts the chosen break point. Added the all-fits and nothing-fits paths, plus a guard that the search stays logarithmic and probe strings don't scale with the remainder.

## Note on the version bump

`__version__` goes to `1.0.2+pptxbuilder.1` (PEP 440 local version), and this is **load-bearing, not cosmetic**.

pptxbuilder pins this fork by branch (`git+https://github.com/mszbot/python-pptx@pptxbuilder`). pip resolves that by *version* — I verified that with an unchanged version it re-clones the branch, sees `1.0.2` already installed, and **skips the install**. The build looks completely normal while the dyno keeps running stale code. A full commit-SHA pin does not fix it either, nor does `--upgrade`; only a version change or `--force-reinstall` does.

A local version segment rather than `1.0.3` so it can't be confused with a future upstream release, and `pip show python-pptx` on a dyno self-identifies as the fork build. **Bump the trailing number on every future fork change that needs to reach a deployed app.**

## Caveat

This makes fitting ~7× faster but it is still superlinear — a deck roughly 3× this one would reach the limit again. If the AI-insight verbatim slides keep growing, the durable fix is capping how much text goes into a single placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)